### PR TITLE
Fix failing smoke and sanity tests as of February 2022

### DIFF
--- a/cypress/integration/common/navigation.ts
+++ b/cypress/integration/common/navigation.ts
@@ -14,6 +14,9 @@ const navBar = new NavbarSection()
 Given('I am already logged in to BMS', () => {
     loginPage.useToken();
 });
+Given('I login to BMS', () => {
+    loginPage.performLogin();
+});
 
 Given('I am on the {} page', (page) => {
     loginPage.performLogin();

--- a/cypress/integration/common/navigation.ts
+++ b/cypress/integration/common/navigation.ts
@@ -41,12 +41,6 @@ And('I navigate to Site Admin page',()=>{
 });
 
 // ==================================
-// ANDS
-And('I am already logged in to BMS', () => {
-    loginPage.performLogin();
-});
-
-// ==================================
 // WHENS
 When('I navigate to {} in the sidebar', (sidebarLink) => {
     sidebarSection.navigateTo(sidebarLink);

--- a/cypress/integration/pageobjects/dashboard-page.ts
+++ b/cypress/integration/pageobjects/dashboard-page.ts
@@ -50,6 +50,7 @@ export default class DashboardPage{
 
     verifyPageLoaded() {
         // Verify Crop dropdown, Program dropdown and Launch buttons
+        closeReleaseNotePopupIfShown();
         this.getProgramsIframeBody().find('#cropDropdown select').should('exist')
         this.getProgramsIframeBody().find('#programDropdown select').should('exist')
         this.getProgramsIframeBody().find('jhi-program > section > div:nth-child(1) > div.col-sm-4 > form > div:nth-child(2) > div.col-sm-auto > button').should('exist')

--- a/cypress/integration/pageobjects/navbar-section.ts
+++ b/cypress/integration/pageobjects/navbar-section.ts
@@ -20,7 +20,6 @@ export default class NavbarSection {
     }
 
     openUserProfilePopup() {
-        closeReleaseNotePopupIfShown();
         cy.get('[data-test="userProfileMenu"]', {timeout: 5000}).should('exist').click();
         cy.get('[data-test="openUserProfileButton"]').should('exist').click();
     }

--- a/cypress/integration/pageobjects/navbar-section.ts
+++ b/cypress/integration/pageobjects/navbar-section.ts
@@ -20,6 +20,7 @@ export default class NavbarSection {
     }
 
     openUserProfilePopup() {
+        closeReleaseNotePopupIfShown();
         cy.get('[data-test="userProfileMenu"]', {timeout: 5000}).should('exist').click();
         cy.get('[data-test="openUserProfileButton"]').should('exist').click();
     }

--- a/cypress/integration/pageobjects/navbar-section.ts
+++ b/cypress/integration/pageobjects/navbar-section.ts
@@ -14,6 +14,7 @@ export default class NavbarSection {
     }
 
     signOut() {
+        closeReleaseNotePopupIfShown();
         cy.xpath('//body/jhi-main/div/section/jhi-navbar/div/mat-toolbar/button[5]/span').should('exist').click();
         cy.xpath('//body/div[2]/div[2]/div/div/div/button').should('exist').should(($sp) => {expect($sp).to.have.text('Sign out')}).click();
     }

--- a/cypress/integration/tests/account-management/create-role.feature
+++ b/cypress/integration/tests/account-management/create-role.feature
@@ -2,7 +2,7 @@
 @account-management
 Feature: Create Role
 Background: 
-    Given I am already logged in to BMS
+    Given I login to BMS
     And I navigate to Site Admin page
 @TestCaseKey=IBP-T76
 @smoke-test

--- a/cypress/integration/tests/account-management/create-role.feature
+++ b/cypress/integration/tests/account-management/create-role.feature
@@ -1,12 +1,12 @@
 @create-role
 @account-management
 Feature: Create Role
-
-@TestCaseKey=IBP-T76
-@smoke-test
-Scenario: Check if user can create new program role in Site Admin
+Background: 
     Given I am already logged in to BMS
     And I navigate to Site Admin page
+@TestCaseKey=IBP-T76
+@smoke-test
+Scenario: Check if user can create new program role in Site Admin 
     When I create a new Program role with valid details
     And I select all available permissions
     Then A message should display that the Program role is successfully saved
@@ -14,8 +14,6 @@ Scenario: Check if user can create new program role in Site Admin
 @TestCaseKey=IBP-T1975
 @smoke-test
 Scenario: Verify creation of new role - full instance permissions
-    Given I am already logged in to BMS
-    And I navigate to Site Admin page
     When I create a new Instance role with valid details
     And I select all available permissions
     Then A message should display that the Instance role is successfully saved
@@ -23,8 +21,6 @@ Scenario: Verify creation of new role - full instance permissions
 @TestCaseKey=IBP-T1976
 @smoke-test
 Scenario: Verify creation of new role - full crop permissions
-    Given I am already logged in to BMS
-    And I navigate to Site Admin page
     When I create a new Crop role with valid details
     And I select all available permissions
     Then A message should display that the Crop role is successfully saved

--- a/cypress/integration/tests/account-management/login.feature
+++ b/cypress/integration/tests/account-management/login.feature
@@ -25,7 +25,7 @@ Feature: Login
 @TestCaseKey=IBP-T78
 @smoke-test
     Scenario: Check if user can sign out in BMS
-        Given I am already logged in to BMS
+        Given I login to BMS
         When I sign out
 		Then I should be redirected to the login page
 

--- a/cypress/integration/tests/account-management/user-profile/user-profile-step-defs.ts
+++ b/cypress/integration/tests/account-management/user-profile/user-profile-step-defs.ts
@@ -1,11 +1,13 @@
 import { After, And, Before, Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
 import UserProfilePage from '../../../pageobjects/account-management/user-profile-page';
 import NavbarSection from '../../../pageobjects/navbar-section';
+import { closeReleaseNotePopupIfShown } from '../../../../support/commands';
 
 const navBar = new NavbarSection();
 const userProfilePage = new UserProfilePage();
 
 Given('I navigate to update user profile screen',()=>{
+    closeReleaseNotePopupIfShown();
     navBar.openUserProfilePopup();
 })
 


### PR DESCRIPTION
**List of Changes:**

- Remove duplicate login to BMS stepdef
- Add closeReleaseNotesPopupIfShown to functions used in navigating to update profile, verify loading of dashboard page and sign out
- Use different step def for sign out to BMS to avoid re-using the same session