### PR TITLE
IBP-5382 Fix Add Germplasm To Existing List On Clean Install

### DIFF
--- a/cypress/integration/tests/manage-germplasm/add-selected-germplasm-to-existing-list.feature
+++ b/cypress/integration/tests/manage-germplasm/add-selected-germplasm-to-existing-list.feature
@@ -5,11 +5,13 @@ Feature: Add Selected Germplasm to Existing List
     As a user I should be able to add selected germplasm to existing list
 
 Background: 
-        Given I reload the Germplasm Manager page
+        Given I am on the Manage Germplasm page of specified program
+        And I create a new list
 
 @TestCaseKey=IBP-T2178
 @smoke-test
-    Scenario: Add selected germplasm entries to an existing list 
+    Scenario: Add selected germplasm entries to an existing list
+        Given I reload the Germplasm Manager page
         When I select some germplasm entries
         And I add select germplasm entries to an existing list
         And I confirm to add selected germplasm to the list

--- a/cypress/integration/tests/manage-germplasm/add-selected-germplasm-to-existing-list/add-selected-germplasm-to-existing-list-step-defs.ts
+++ b/cypress/integration/tests/manage-germplasm/add-selected-germplasm-to-existing-list/add-selected-germplasm-to-existing-list-step-defs.ts
@@ -10,18 +10,17 @@ const germplasmListAddToListPage = new GermplasmListAddToListPage();
 const existingListName = 'TestListName' + randomString();
 let existingListId: any;
 
-
-before(() => {
-    // Before all the scenarios are executed, login first and navigate to Germplasm Manager
-    loginAndNavigateToPage('Germplasm Manager');
-    // Create new germplasm list first
-    manageGermplasmPage.waitForGermplasmSearchResultsToLoad().then(() => {
-        manageGermplasmPage.selectAllCurrentPage();
-    });
-    manageGermplasmPage.clickCreateNewListAction();
-    manageGermplasmPage.clickSaveList(existingListName).then((listId) => {
-        existingListId = listId;
-    });
+And('I create a new list', () => {
+    // Create a new list only once before executing all test scenarios.
+    if (!existingListId) {
+        manageGermplasmPage.waitForGermplasmSearchResultsToLoad().then(() => {
+            manageGermplasmPage.selectAllCurrentPage();
+        });
+        manageGermplasmPage.clickCreateNewListAction();
+        manageGermplasmPage.clickSaveList(existingListName).then((listId) => {
+            existingListId = listId;
+        });
+    }
 });
 
 When('I filter some germplasm entries by GID', () => {


### PR DESCRIPTION
Remove usage of before(). Create a new list only once before all tests are executed.